### PR TITLE
Add additional packets for building libdrm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,9 @@ RUN DEBIAN_FRONTEND=noninteractive \
 RUN DEBIAN_FRONTEND=noninteractive \
 	apt-get -y --no-install-recommends install \
 		autotools-dev \
-		automake
+		automake \
+		xutils-dev \
+		libtool
 
 RUN apt-get clean
 RUN rm -rf /var/lib/apt /var/cache/apt


### PR DESCRIPTION
Fixes 9326e2430c760019da126ebfdd9f30191fd9c980

I checked the build locally.

